### PR TITLE
fix: device metadata for multiple users on single device

### DIFF
--- a/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
+++ b/packages/auth/__tests__/providers/cognito/tokenProvider.test.ts
@@ -1,0 +1,339 @@
+import { KeyValueStorageInterface } from '@aws-amplify/core';
+import { DefaultTokenStore } from '../../../src/providers/cognito';
+import { decodeJWT } from '@aws-amplify/core/internals/utils';
+
+class MemoryStorage implements KeyValueStorageInterface {
+	store: Record<string, string> = {};
+	async setItem(key: string, value: string): Promise<void> {
+		this.store[key] = value;
+	}
+	async getItem(key: string): Promise<string | null> {
+		return this.store[key];
+	}
+	async removeItem(key: string): Promise<void> {
+		delete this.store[key];
+	}
+	async clear(): Promise<void> {
+		this.store = {};
+	}
+}
+
+describe('Loading tokens', () => {
+	test('load tokens from store', async () => {
+		const tokenStore = new DefaultTokenStore();
+		const memoryStorage = new MemoryStorage();
+		const userPoolClientId = 'abcdefgh';
+		const userSub = 'user123';
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.LastAuthUser`,
+			userSub
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.accessToken`,
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.Y'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.idToken`,
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.Y'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.refreshToken`,
+			'dsasdasdasdasdasdasdasd'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.clockDrift`,
+			'10'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.deviceKey`,
+			'device-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.deviceGroupKey`,
+			'device-group-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${userSub}.randomPasswordKey`,
+			'random-password'
+		);
+
+		tokenStore.setKeyValueStorage(memoryStorage);
+		tokenStore.setAuthConfig({
+			Cognito: {
+				userPoolId: 'us-east-1:1111111',
+				userPoolClientId,
+			},
+		});
+		const result = await tokenStore.loadTokens();
+
+		expect(result?.accessToken.toString()).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.Y'
+		);
+		expect(result?.idToken?.toString()).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.Y'
+		);
+		expect(result?.clockDrift).toBe(10);
+		expect(result?.refreshToken).toBe('dsasdasdasdasdasdasdasd');
+		expect(result?.deviceMetadata?.deviceGroupKey).toBe('device-group-key');
+		expect(result?.deviceMetadata?.randomPassword).toBe('random-password');
+		expect(result?.deviceMetadata?.deviceKey).toBe('device-key');
+	});
+});
+
+describe('saving tokens', () => {
+	test('save tokens from store first time', async () => {
+		const tokenStore = new DefaultTokenStore();
+		const memoryStorage = new MemoryStorage();
+		const userPoolClientId = 'abcdefgh';
+
+		tokenStore.setKeyValueStorage(memoryStorage);
+		tokenStore.setAuthConfig({
+			Cognito: {
+				userPoolId: 'us-east-1:1111111',
+				userPoolClientId,
+			},
+		});
+
+		await tokenStore.storeTokens({
+			accessToken: decodeJWT(
+				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
+			),
+			idToken: decodeJWT(
+				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.III'
+			),
+			clockDrift: 150,
+			refreshToken: 'refresh-token',
+			deviceMetadata: {
+				deviceKey: 'device-key2',
+				deviceGroupKey: 'device-group-key2',
+				randomPassword: 'random-password2',
+			},
+			username: 'amplify@user',
+		});
+
+		const usernameDecoded = 'amplify%40user';
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.LastAuthUser`
+			)
+		).toBe(usernameDecoded); // from decoded JWT
+
+		// Refreshed tokens
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.accessToken`
+			)
+		).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
+		);
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.idToken`
+			)
+		).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.III'
+		);
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.refreshToken`
+			)
+		).toBe('refresh-token');
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.clockDrift`
+			)
+		).toBe('150');
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.deviceKey`
+			)
+		).toBe('device-key2');
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.deviceGroupKey`
+			)
+		).toBe('device-group-key2');
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameDecoded}.randomPasswordKey`
+			)
+		).toBe('random-password2');
+	});
+	test('save tokens from store clear old tokens', async () => {
+		const tokenStore = new DefaultTokenStore();
+		const memoryStorage = new MemoryStorage();
+		const userPoolClientId = 'abcdefgh';
+		const oldUserName = 'amplify@user';
+
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.LastAuthUser`,
+			oldUserName
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.accessToken`,
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.Y'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.idToken`,
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzB9.Y'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.refreshToken`,
+			'dsasdasdasdasdasdasdasd'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.clockDrift`,
+			'10'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceKey`,
+			'device-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceGroupKey`,
+			'device-group-key'
+		);
+		memoryStorage.setItem(
+			`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.randomPasswordKey`,
+			'random-password'
+		);
+
+		tokenStore.setKeyValueStorage(memoryStorage);
+		tokenStore.setAuthConfig({
+			Cognito: {
+				userPoolId: 'us-east-1:1111111',
+				userPoolClientId,
+			},
+		});
+
+		await tokenStore.storeTokens({
+			accessToken: decodeJWT(
+				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
+			),
+			idToken: decodeJWT(
+				'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.III'
+			),
+			clockDrift: 150,
+			refreshToken: 'refresh-token',
+			deviceMetadata: {
+				deviceKey: 'device-key2',
+				deviceGroupKey: 'device-group-key2',
+				randomPassword: 'random-password2',
+			},
+			username: 'amplify@user',
+		});
+
+		const usernameEncoded = 'amplify%40user';
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.LastAuthUser`
+			)
+		).toBe(usernameEncoded); // from decoded JWT
+
+		// Refreshed tokens
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.accessToken`
+			)
+		).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.AAA'
+		);
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.idToken`
+			)
+		).toBe(
+			'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3MTAyOTMxMzAsInVzZXJuYW1lIjoiYW1wbGlmeUB1c2VyIn0.III'
+		);
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.refreshToken`
+			)
+		).toBe('refresh-token');
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.clockDrift`
+			)
+		).toBe('150');
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.deviceKey`
+			)
+		).toBe('device-key2');
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.deviceGroupKey`
+			)
+		).toBe('device-group-key2');
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${usernameEncoded}.randomPasswordKey`
+			)
+		).toBe('random-password2');
+
+		// old tokens cleared
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.accessToken`
+			)
+		).toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.idToken`
+			)
+		).toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.refreshToken`
+			)
+		).toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.clockDrift`
+			)
+		).toBeUndefined();
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.idToken`
+			)
+		).toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.refreshToken`
+			)
+		).toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.clockDrift`
+			)
+		).toBeUndefined();
+
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceKey`
+			)
+		).not.toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.deviceGroupKey`
+			)
+		).not.toBeUndefined();
+		expect(
+			await memoryStorage.getItem(
+				`CognitoIdentityServiceProvider.${userPoolClientId}.${oldUserName}.randomPasswordKey`
+			)
+		).not.toBeUndefined();
+	});
+});

--- a/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
+++ b/packages/auth/src/providers/cognito/apis/confirmSignIn.ts
@@ -111,6 +111,7 @@ export async function confirmSignIn(
 		if (AuthenticationResult) {
 			cleanActiveSignInState();
 			await cacheCognitoTokens({
+				username,
 				...AuthenticationResult,
 				NewDeviceMetadata: await getNewDeviceMetatada(
 					authConfig.userPoolId,

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomAuth.ts
@@ -81,6 +81,7 @@ export async function signInWithCustomAuth(
 			cleanActiveSignInState();
 
 			await cacheCognitoTokens({
+				username,
 				...AuthenticationResult,
 				NewDeviceMetadata: await getNewDeviceMetatada(
 					authConfig.userPoolId,

--- a/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithCustomSRPAuth.ts
@@ -84,6 +84,7 @@ export async function signInWithCustomSRPAuth(
 		});
 		if (AuthenticationResult) {
 			await cacheCognitoTokens({
+				username,
 				...AuthenticationResult,
 				NewDeviceMetadata: await getNewDeviceMetatada(
 					authConfig.userPoolId,

--- a/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithSRP.ts
@@ -82,6 +82,7 @@ export async function signInWithSRP(
 		if (AuthenticationResult) {
 			cleanActiveSignInState();
 			await cacheCognitoTokens({
+				username,
 				...AuthenticationResult,
 				NewDeviceMetadata: await getNewDeviceMetatada(
 					authConfig.userPoolId,

--- a/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
+++ b/packages/auth/src/providers/cognito/apis/signInWithUserPassword.ts
@@ -81,6 +81,7 @@ export async function signInWithUserPassword(
 		if (AuthenticationResult) {
 			await cacheCognitoTokens({
 				...AuthenticationResult,
+				username,
 				NewDeviceMetadata: await getNewDeviceMetatada(
 					authConfig.userPoolId,
 					AuthenticationResult.NewDeviceMetadata,

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -80,12 +80,12 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 		const idTokenExpired =
 			!!tokens?.idToken &&
 			isTokenExpired({
-				expiresAt: (tokens.idToken?.payload?.exp || 0) * 1000,
-				clockDrift: tokens.clockDrift || 0,
+				expiresAt: (tokens.idToken?.payload?.exp ?? 0) * 1000,
+				clockDrift: tokens.clockDrift ?? 0,
 			});
 		const accessTokenExpired = isTokenExpired({
-			expiresAt: (tokens.accessToken?.payload?.exp || 0) * 1000,
-			clockDrift: tokens.clockDrift || 0,
+			expiresAt: (tokens.accessToken?.payload?.exp ?? 0) * 1000,
+			clockDrift: tokens.clockDrift ?? 0,
 		});
 
 		if (options?.forceRefresh || idTokenExpired || accessTokenExpired) {

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenOrchestrator.ts
@@ -150,10 +150,10 @@ export class TokenOrchestrator implements AuthTokenOrchestrator {
 		return this.getTokenStore().clearTokens();
 	}
 
-	getDeviceMetadata(): Promise<DeviceMetadata | null> {
-		return this.getTokenStore().getDeviceMetadata();
+	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null> {
+		return this.getTokenStore().getDeviceMetadata(username);
 	}
-	clearDeviceMetadata(): Promise<void> {
-		return this.getTokenStore().clearDeviceMetadata();
+	clearDeviceMetadata(username?: string): Promise<void> {
+		return this.getTokenStore().clearDeviceMetadata(username);
 	}
 }

--- a/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/TokenStore.ts
@@ -18,8 +18,7 @@ import { assert, TokenProviderErrorCode } from './errorHelpers';
 export class DefaultTokenStore implements AuthTokenStore {
 	private authConfig?: AuthConfig;
 	keyValueStorage?: KeyValueStorageInterface;
-	private name = 'Cognito'; // TODO(v6): update after API review for Amplify.configure
-	private authKeys: AuthKeys<keyof typeof AuthTokenStorageKeys> | undefined;
+	private name = 'CognitoIdentityServiceProvider'; // To be backwards compatible with V5, no migration needed
 	getKeyValueStorage(): KeyValueStorageInterface {
 		if (!this.keyValueStorage) {
 			throw new AuthError({
@@ -40,8 +39,9 @@ export class DefaultTokenStore implements AuthTokenStore {
 		// TODO(v6): migration logic should be here
 		// Reading V5 tokens old format
 		try {
+			const authKeys = await this.getAuthKeys();
 			const accessTokenString = await this.getKeyValueStorage().getItem(
-				this.getAuthKeys().accessToken
+				authKeys.accessToken
 			);
 
 			if (!accessTokenString) {
@@ -53,19 +53,16 @@ export class DefaultTokenStore implements AuthTokenStore {
 
 			const accessToken = decodeJWT(accessTokenString);
 			const itString = await this.getKeyValueStorage().getItem(
-				this.getAuthKeys().idToken
+				authKeys.idToken
 			);
 			const idToken = itString ? decodeJWT(itString) : undefined;
 
 			const refreshToken =
-				(await this.getKeyValueStorage().getItem(
-					this.getAuthKeys().refreshToken
-				)) ?? undefined;
+				(await this.getKeyValueStorage().getItem(authKeys.refreshToken)) ??
+				undefined;
 
 			const clockDriftString =
-				(await this.getKeyValueStorage().getItem(
-					this.getAuthKeys().clockDrift
-				)) || '0';
+				(await this.getKeyValueStorage().getItem(authKeys.clockDrift)) ?? '0';
 			const clockDrift = Number.parseInt(clockDriftString);
 
 			return {
@@ -74,6 +71,7 @@ export class DefaultTokenStore implements AuthTokenStore {
 				refreshToken,
 				deviceMetadata: (await this.getDeviceMetadata()) ?? undefined,
 				clockDrift,
+				username: decodeURIComponent(await this.getLastAuthUser()),
 			};
 		} catch (err) {
 			return null;
@@ -81,73 +79,124 @@ export class DefaultTokenStore implements AuthTokenStore {
 	}
 	async storeTokens(tokens: CognitoAuthTokens): Promise<void> {
 		assert(tokens !== undefined, TokenProviderErrorCode.InvalidAuthTokens);
+		await this.clearTokens();
 
-		this.getKeyValueStorage().setItem(
-			this.getAuthKeys().accessToken,
+		const lastAuthUser =
+			(tokens.username && encodeURIComponent(tokens.username)) ?? 'username';
+		await this.getKeyValueStorage().setItem(
+			this.getLastAuthUserKey(),
+			lastAuthUser
+		);
+		const authKeys = await this.getAuthKeys();
+		await this.getKeyValueStorage().setItem(
+			authKeys.accessToken,
 			tokens.accessToken.toString()
 		);
 
 		if (!!tokens.idToken) {
-			this.getKeyValueStorage().setItem(
-				this.getAuthKeys().idToken,
+			await this.getKeyValueStorage().setItem(
+				authKeys.idToken,
 				tokens.idToken.toString()
 			);
 		}
 
 		if (!!tokens.refreshToken) {
-			this.getKeyValueStorage().setItem(
-				this.getAuthKeys().refreshToken,
+			await this.getKeyValueStorage().setItem(
+				authKeys.refreshToken,
 				tokens.refreshToken
 			);
 		}
 
 		if (!!tokens.deviceMetadata) {
-			this.getKeyValueStorage().setItem(
-				this.getAuthKeys().deviceMetadata,
-				JSON.stringify(tokens.deviceMetadata)
+			if (tokens.deviceMetadata.deviceKey) {
+				await this.getKeyValueStorage().setItem(
+					authKeys.deviceKey,
+					tokens.deviceMetadata.deviceKey
+				);
+			}
+			if (tokens.deviceMetadata.deviceGroupKey) {
+				await this.getKeyValueStorage().setItem(
+					authKeys.deviceGroupKey,
+					tokens.deviceMetadata.deviceGroupKey
+				);
+			}
+
+			await this.getKeyValueStorage().setItem(
+				authKeys.randomPasswordKey,
+				tokens.deviceMetadata.randomPassword
 			);
 		}
 
-		this.getKeyValueStorage().setItem(
-			this.getAuthKeys().clockDrift,
+		await this.getKeyValueStorage().setItem(
+			authKeys.clockDrift,
 			`${tokens.clockDrift}`
 		);
 	}
 
 	async clearTokens(): Promise<void> {
+		const authKeys = await this.getAuthKeys();
 		// Not calling clear because it can remove data that is not managed by AuthTokenStore
 		await Promise.all([
-			this.getKeyValueStorage().removeItem(this.getAuthKeys().accessToken),
-			this.getKeyValueStorage().removeItem(this.getAuthKeys().idToken),
-			this.getKeyValueStorage().removeItem(this.getAuthKeys().clockDrift),
-			this.getKeyValueStorage().removeItem(this.getAuthKeys().refreshToken),
+			this.getKeyValueStorage().removeItem(authKeys.accessToken),
+			this.getKeyValueStorage().removeItem(authKeys.idToken),
+			this.getKeyValueStorage().removeItem(authKeys.clockDrift),
+			this.getKeyValueStorage().removeItem(authKeys.refreshToken),
+			this.getKeyValueStorage().removeItem(this.getLastAuthUserKey()),
 		]);
 	}
 
 	async getDeviceMetadata(): Promise<DeviceMetadata | null> {
-		const newDeviceMetadata = JSON.parse(
-			(await this.getKeyValueStorage().getItem(
-				this.getAuthKeys().deviceMetadata
-			)) || '{}'
+		const authKeys = await this.getAuthKeys();
+		const deviceKey = await this.getKeyValueStorage().getItem(
+			authKeys.deviceKey
 		);
-		const deviceMetadata =
-			Object.keys(newDeviceMetadata).length > 0 ? newDeviceMetadata : null;
-		return deviceMetadata;
+		const deviceGroupKey = await this.getKeyValueStorage().getItem(
+			authKeys.deviceGroupKey
+		);
+		const randomPassword = await this.getKeyValueStorage().getItem(
+			authKeys.randomPasswordKey
+		);
+
+		return !!randomPassword
+			? {
+					deviceKey: deviceKey ?? undefined,
+					deviceGroupKey: deviceGroupKey ?? undefined,
+					randomPassword,
+			  }
+			: null;
 	}
 	async clearDeviceMetadata(): Promise<void> {
-		await this.getKeyValueStorage().removeItem(
-			this.getAuthKeys().deviceMetadata
+		const authKeys = await this.getAuthKeys();
+		await Promise.all([
+			this.getKeyValueStorage().removeItem(authKeys.deviceKey),
+			this.getKeyValueStorage().removeItem(authKeys.deviceGroupKey),
+			this.getKeyValueStorage().removeItem(authKeys.randomPasswordKey),
+		]);
+	}
+
+	private async getAuthKeys(): Promise<
+		AuthKeys<keyof typeof AuthTokenStorageKeys>
+	> {
+		assertTokenProviderConfig(this.authConfig?.Cognito);
+		const lastAuthUser = await this.getLastAuthUser();
+		return createKeysForAuthStorage(
+			this.name,
+			`${this.authConfig.Cognito.userPoolClientId}.${lastAuthUser}`
 		);
 	}
 
-	private getAuthKeys(): AuthKeys<keyof typeof AuthTokenStorageKeys> {
+	private getLastAuthUserKey() {
 		assertTokenProviderConfig(this.authConfig?.Cognito);
-		if (this.authKeys) return this.authKeys;
-		this.authKeys = createKeysForAuthStorage(
-			this.name,
-			this.authConfig.Cognito.userPoolClientId
-		);
-		return this.authKeys;
+		const identifier = this.authConfig.Cognito.userPoolClientId;
+		return `${this.name}.${identifier}.LastAuthUser`;
+	}
+
+	private async getLastAuthUser(): Promise<string> {
+		const lastAuthUser =
+			(await this.getKeyValueStorage().getItem(this.getLastAuthUserKey())) ??
+			'username';
+
+		return lastAuthUser;
 	}
 }
 
@@ -155,10 +204,7 @@ export const createKeysForAuthStorage = (
 	provider: string,
 	identifier: string
 ) => {
-	return getAuthStorageKeys(AuthTokenStorageKeys)(
-		`com.amplify.${provider}`,
-		identifier
-	);
+	return getAuthStorageKeys(AuthTokenStorageKeys)(`${provider}`, identifier);
 };
 
 export function getAuthStorageKeys<T extends Record<string, string>>(

--- a/packages/auth/src/providers/cognito/tokenProvider/cacheTokens.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/cacheTokens.ts
@@ -8,6 +8,7 @@ import { DeviceMetadata } from './types';
 export async function cacheCognitoTokens(
 	AuthenticationResult: AuthenticationResultType & {
 		NewDeviceMetadata?: DeviceMetadata;
+		username: string;
 	}
 ): Promise<void> {
 	if (AuthenticationResult.AccessToken) {
@@ -34,13 +35,14 @@ export async function cacheCognitoTokens(
 			deviceMetadata = AuthenticationResult.NewDeviceMetadata;
 		}
 
-		tokenOrchestrator.setTokens({
+		await tokenOrchestrator.setTokens({
 			tokens: {
 				accessToken,
 				idToken,
 				refreshToken,
 				clockDrift,
 				deviceMetadata,
+				username: AuthenticationResult.username,
 			},
 		});
 	} else {

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -26,7 +26,9 @@ export const AuthTokenStorageKeys = {
 	oidcProvider: 'oidcProvider',
 	clockDrift: 'clockDrift',
 	refreshToken: 'refreshToken',
-	deviceMetadata: 'deviceMetadata',
+	deviceKey: 'deviceKey',
+	randomPasswordKey: 'randomPasswordKey',
+	deviceGroupKey: 'deviceGroupKey',
 };
 
 export interface AuthTokenStore {
@@ -57,6 +59,7 @@ export type CognitoAuthTokens = AuthTokens & {
 	refreshToken?: string;
 	deviceMetadata?: DeviceMetadata;
 	clockDrift: number;
+	username: string;
 };
 
 export type DeviceMetadata = {

--- a/packages/auth/src/providers/cognito/tokenProvider/types.ts
+++ b/packages/auth/src/providers/cognito/tokenProvider/types.ts
@@ -36,8 +36,8 @@ export interface AuthTokenStore {
 	storeTokens(tokens: CognitoAuthTokens): Promise<void>;
 	clearTokens(): Promise<void>;
 	setKeyValueStorage(keyValueStorage: KeyValueStorageInterface): void;
-	getDeviceMetadata(): Promise<DeviceMetadata | null>;
-	clearDeviceMetadata(): Promise<void>;
+	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
+	clearDeviceMetadata(username?: string): Promise<void>;
 }
 
 export interface AuthTokenOrchestrator {
@@ -46,8 +46,8 @@ export interface AuthTokenOrchestrator {
 	getTokens: (options?: FetchAuthSessionOptions) => Promise<AuthTokens | null>;
 	setTokens: ({ tokens }: { tokens: CognitoAuthTokens }) => Promise<void>;
 	clearTokens: () => Promise<void>;
-	getDeviceMetadata(): Promise<DeviceMetadata | null>;
-	clearDeviceMetadata(): Promise<void>;
+	getDeviceMetadata(username?: string): Promise<DeviceMetadata | null>;
+	clearDeviceMetadata(username?: string): Promise<void>;
 }
 
 export interface CognitoUserPoolTokenProviderType extends TokenProvider {

--- a/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
+++ b/packages/auth/src/providers/cognito/utils/refreshAuthTokens.ts
@@ -59,5 +59,6 @@ export const refreshAuthTokens: TokenRefresher = async ({
 		idToken,
 		clockDrift,
 		refreshToken,
+		username: `${accessToken.payload.username}`,
 	};
 };

--- a/packages/auth/src/providers/cognito/utils/signInHelpers.ts
+++ b/packages/auth/src/providers/cognito/utils/signInHelpers.ts
@@ -91,7 +91,7 @@ export async function handleCustomChallenge({
 		ANSWER: challengeResponse,
 	};
 
-	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata(username);
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		challengeResponses['DEVICE_KEY'] = deviceMetadata.deviceKey;
 	}
@@ -267,7 +267,7 @@ export async function handleUserPasswordAuthFlow(
 		USERNAME: username,
 		PASSWORD: password,
 	};
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		authParameters['DEVICE_KEY'] = deviceMetadata.deviceKey;
@@ -310,7 +310,7 @@ export async function handleUserSRPAuthFlow(
 		USERNAME: username,
 		SRP_A: authenticationHelper.A.toString(16),
 	};
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		authParameters['DEVICE_KEY'] = deviceMetadata.deviceKey;
@@ -346,7 +346,7 @@ export async function handleCustomAuthFlowWithoutSRP(
 	const authParameters: Record<string, string> = {
 		USERNAME: username,
 	};
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		authParameters['DEVICE_KEY'] = deviceMetadata.deviceKey;
@@ -386,7 +386,7 @@ export async function handleCustomSRPAuthFlow(
 	const userPoolName = userPoolId?.split('_')[1] || '';
 	const authenticationHelper = await getAuthenticationHelper(userPoolName);
 
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 
 	const authParameters: Record<string, string> = {
 		USERNAME: username,
@@ -427,7 +427,7 @@ async function handleDeviceSRPAuth({
 }: HandleDeviceSRPInput): Promise<RespondToAuthChallengeCommandOutput> {
 	const userPoolId = config.userPoolId;
 	const clientId = config.userPoolClientId;
-	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata(username);
 	assertDeviceMetadata(deviceMetadata);
 	const authenticationHelper = await getAuthenticationHelper(
 		deviceMetadata.deviceGroupKey
@@ -470,7 +470,7 @@ async function handleDevicePasswordVerifier(
 	{ userPoolId, userPoolClientId }: CognitoUserPoolConfig,
 	tokenOrchestrator?: AuthTokenOrchestrator
 ): Promise<RespondToAuthChallengeCommandOutput> {
-	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator?.getDeviceMetadata(username);
 	assertDeviceMetadata(deviceMetadata);
 
 	const serverBValue = new BigInteger(challengeParameters?.SRP_B, 16);
@@ -554,7 +554,7 @@ export async function handlePasswordVerifierChallenge(
 		}),
 	} as { [key: string]: string };
 
-	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata();
+	const deviceMetadata = await tokenOrchestrator.getDeviceMetadata(username);
 	if (deviceMetadata && deviceMetadata.deviceKey) {
 		challengeResponses['DEVICE_KEY'] = deviceMetadata.deviceKey;
 	}


### PR DESCRIPTION
### Description of changes
fix: device metadata for multiple users on single device

### Testing Performed
user1 -> signIn -> confirmSignIn() -> rememberdevice()
user1 -> signIn (bypass MFA )
user1 -> signOut

user2 -> signIn -> confirmSignIn() -> rememberdevice()
user2 -> signIn (bypass MFA)
user2 -> signOut

user1 -> signIn (bypass MFA) -> signOut
user2 -> signIn (bypass MFA) -> signOut
user1 -> signIn (bypass MFA) -> signOut
user2 -> signIn (bypass MFA) -> signOut

confirmed localStore deviceMetadata for both users co-exist   


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
